### PR TITLE
use line awesome in sidebar menu item

### DIFF
--- a/src/Views/sidebarMenuItem.blade.php
+++ b/src/Views/sidebarMenuItem.blade.php
@@ -3,7 +3,7 @@ $unreadNotificationsCount = backpack_user()->unreadNotifications()->count();
 @endphp
 
  <li class="nav-item">
-	<a class="nav-link" href="{{ backpack_url('notification') }}"><i class="fa nav-icon fa-bell"></i> <span>Notifications</span>
+	<a class="nav-link" href="{{ backpack_url('notification') }}"><i class="nav-icon la la-bell"></i> <span>Notifications</span>
 		<span class="pull-right-container">
 			<small 
 				class="unreadnotificationscount badge badge-secondary pull-right {{($unreadNotificationsCount)? 'bg-primary' : 'bg-secondary'}}" 


### PR DESCRIPTION
When installing this in Backpack 4.1 the sidebar item didn't show any icon for me:

<img width="231" alt="Screenshot 2021-10-10 at 12 08 31" src="https://user-images.githubusercontent.com/1032474/136689602-ba57fc08-00cb-467f-b9af-55429c56d0d9.png">

I discovered that was because it was using FontAwesome, not LineAwesome which Backpack comes bundled with. 

This PR fixes that:

<img width="230" alt="Screenshot 2021-10-10 at 12 09 57" src="https://user-images.githubusercontent.com/1032474/136689637-3c47a9a1-b050-406a-9727-857004d90fe8.png">


