### PR TITLE
action buttons on one line and uppercase

### DIFF
--- a/src/Models/Notification.php
+++ b/src/Models/Notification.php
@@ -60,12 +60,11 @@ class Notification extends Model
     public function actionButton()
     {
         $str = '';
-        if (! empty($this->data->action)) {
-            $str = '<a href="'.$this->data->action->url.'" class="btn btn-primary btn-xs mb-1">'.$this->data->action->title.'</a><br>';
+        if (!empty($this->data->action)) {
+            $str = '<a href="' . $this->data->action->url . '" class="btn btn-primary">' . ucfirst($this->data->action->title) . '</a>';
         } elseif ($this->data->action_href ?? false) {
-            $str = '<a href="'.$this->data->action_href.'" class="btn btn-primary btn-xs mb-1">'.$this->data->action_text.'</a><br>';
+            $str = '<a href="' . $this->data->action_href . '" class="btn btn-primary">' . ucfirst($this->data->action_text) . '</a>';
         }
-
         return $str;
     }
 }


### PR DESCRIPTION
Removed the `<br>`s and uppercased the first character of action buttons. I think this improves the UI a bit, especially for one-line notifications. No reason for the buttons to take up multiple lines if they can take up one line, if you ask me.

Opinionated change, of course. Feel free to close if you don't agree.

Cheers!