### PR TITLE
Closure is deprecated in Backpack v5

### DIFF
--- a/src/Http/Controllers/NotificationCrudController.php
+++ b/src/Http/Controllers/NotificationCrudController.php
@@ -97,9 +97,9 @@ class NotificationCrudController extends CrudController
         $this->crud->addColumn([
             'name' => 'message',
             'label' => 'Message',
-            'type' => 'closure',
+            'type' => 'custom_html',
             'priority' => -1,
-            'function' => function ($entry) {
+            'value' => function ($entry) {
                 return '<div style="display:inline-block; max-width:100%; white-space: pre-wrap;">'.
                     ($entry->data->message_long ?? $entry->data->message ?? '-').
                     '</div>';


### PR DESCRIPTION
I think you will need to update this column to custom_html?

https://backpackforlaravel.com/docs/5.x/crud-columns#closure-1